### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 An implementation of skip-thought vectors in Tensorflow
 
 # Usage
-```python3
+```python
 from skipthought import SkipthoughtModel
 from skipthought.data_utils import TextData
 from skipthought.utils import seq2seq_triples_data_iterator


### PR DESCRIPTION
`python3` might not be a valid syntax decoration tag for markdown