### PR TITLE
adding also to word_freq dict when adding new word into textdata.

### DIFF
--- a/skipthought/data_utils.py
+++ b/skipthought/data_utils.py
@@ -97,6 +97,7 @@ class Vocab:
             index = len(self.word2index)
             self.word2index[word] = index
             self.index2word[index] = word
+            self.word_freq[word] = 0
         self.word_freq[word] += count
 
     def add_words(self, words):


### PR DESCRIPTION
I think function `add_word` have to add word to word_freq also when word is not presented into word2index.
 